### PR TITLE
Fix for wrongly handled jwt error

### DIFF
--- a/app.js
+++ b/app.js
@@ -50,7 +50,7 @@ app.all("*", function(req, res) {
 
 app.use((err, req, res) => {
 	if(err.name == "UnauthorizedError"){
-		return apiResponse.unauthorizedResponse(res, err.message);
+		apiResponse.unauthorizedResponse(res, err.message);
 	}
 });
 


### PR DESCRIPTION
Previously the Error wasn't handled completely and was passed on. That ended up throwing the entire Error as html to response. Which exposed the source files and line numbers.